### PR TITLE
ci: sign sidecar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 build: prebuild
-	@# i need the nO_STRIP=true for some reason, otherwise:
-	@# > Error failed to bundle project: `failed to run linuxdeploy`"
-	NO_STRIP=true npm run tauri build
+	@# Set NO_STRIP=true on Linux to avoid "failed to run linuxdeploy" error
+	@if [ "$$(uname)" = "Linux" ]; then \
+		echo "Building on Linux, setting NO_STRIP=true..."; \
+		NO_STRIP=true npm run tauri build; \
+	else \
+		echo "Building on non-Linux platform..."; \
+		npm run tauri build; \
+	fi
 
 dev: prebuild
 	npm run tauri dev


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `Makefile` to conditionally set `NO_STRIP=true` on Linux to avoid `linuxdeploy` error during build.
> 
>   - **Build Process**:
>     - Modify `build` target in `Makefile` to conditionally set `NO_STRIP=true` on Linux to avoid `linuxdeploy` error.
>     - On non-Linux platforms, `NO_STRIP` is not set during the build process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-tauri&utm_source=github&utm_medium=referral)<sup> for a33d4473fcf0ecb5506c48769c8a2e266c8eb3df. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->